### PR TITLE
Remove brotli module directives from nginx config

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -13,11 +13,6 @@ server {
   gzip_types text/plain text/css application/javascript application/json application/pdf image/svg+xml;
   gzip_min_length 256;
 
-  brotli on;
-  brotli_static on;
-  brotli_comp_level 5;
-  brotli_types text/plain text/css application/javascript application/json image/svg+xml;
-
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,7 @@
-load_module modules/ngx_http_brotli_filter_module.so;
-load_module modules/ngx_http_brotli_static_module.so;
-
+# The Brotli dynamic modules are not guaranteed to be available in every
+# runtime environment (or may be compiled against a different Nginx
+# version). Loading them unconditionally causes Nginx to fail to start when
+# the modules are missing or ABI incompatible, so we omit them here.
 events {}
 
 http {


### PR DESCRIPTION
## Summary
- remove the explicit Brotli module loading directives that crash when the modules are unavailable or ABI incompatible
- strip the Brotli configuration so nginx no longer references directives that require the optional module

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd3a987f5883259bff8734171db13e